### PR TITLE
Windows compatibility

### DIFF
--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -1,4 +1,4 @@
-def cli = new CliBuilder(usage: 'log4j2-migrator [options] input-file')
+def cli = new groovy.cli.commons.CliBuilder(usage: 'log4j2-migrator [options] input-file')
 cli.with {
     h(longOpt: 'help', 'usage information', required: false)
     o(longOpt: 'output', 'file to write the output', required: false, args: 1)
@@ -7,7 +7,7 @@ cli.with {
     a(longOpt: 'async', 'use async loggers', required: false, args: 1, defaultValue: "false", type: Boolean)
 }
 
-OptionAccessor opt = cli.parse(args)
+groovy.cli.commons.OptionAccessor opt = cli.parse(args)
 if (!opt) {
     return
 }


### PR DESCRIPTION
Unsure why, but received the following errors when running on Windows through git-bash:

```bash
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
D:\apps\log4j2migrator.groovy: 1: unable to resolve class CliBuilder
 @ line 1, column 11.
   def cli = new CliBuilder(usage: 'log4j2-migrator [options] input-file')
             ^

D:\apps\log4j2migrator.groovy: 10: unable to resolve class OptionAccessor
 @ line 10, column 16.
   OptionAccessor opt = cli.parse(args)
                  ^

2 errors
```

Specifying the full package works on both.

Original script was tested on Mac with Groovy version 3.0.9, while Groovy on Windows is 4.0.0.
