### PR TITLE
Support system properties with default values (no interpolation)

### DIFF
--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -178,11 +178,7 @@ def generate(bindings) {
                     if (async) {
                         loggerName = 'AsyncLogger'
                     }
-                    def logLevel = value[0].trim()
-                    def propertyPlaceholderMatch = logLevel =~ /\$\{(.*?)\}/
-                    if (propertyPlaceholderMatch) {
-                        logLevel = "\${sys:${propertyPlaceholderMatch.group(1)}}"
-                    }
+                    def logLevel = getLogLevel(value[0].trim())
                     "$loggerName" (name: name, level: logLevel, additivity: additivites[name] ?: 'false') {
                         if (value.size() > 1) {
                             def loggerAppenders = value[1..-1]
@@ -196,11 +192,7 @@ def generate(bindings) {
                 if (async) {
                     loggerName = 'AsyncRoot'
                 }
-                def logLevel = bindings['rootLevel']
-                def propertyPlaceholderMatch = logLevel =~ /\$\{(.*?)\}/
-                if (propertyPlaceholderMatch) {
-                    logLevel = "\${sys:${propertyPlaceholderMatch.group(1)}}"
-                }
+                def logLevel = getLogLevel(bindings['rootLevel'])
                 "$loggerName" (level: logLevel) {
                     bindings['rootAppenders'].each { name ->
                         AppenderRef (ref:name.trim())
@@ -211,4 +203,12 @@ def generate(bindings) {
 
     xmlWriter.append(System.getProperty("line.separator"))
     return xmlWriter.toString()
+}
+
+def getLogLevel(logLevel) {
+    def propertyPlaceholderMatch = logLevel =~ /\$\{(.*?)\}/
+    if (propertyPlaceholderMatch) {
+        logLevel = "\${sys:${propertyPlaceholderMatch.group(1)}}"
+    }
+    return logLevel
 }

--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -196,7 +196,12 @@ def generate(bindings) {
                 if (async) {
                     loggerName = 'AsyncRoot'
                 }
-                "$loggerName" (level:bindings['rootLevel']) {
+                def logLevel = bindings['rootLevel']
+                def propertyPlaceholderMatch = logLevel =~ /\$\{(.*?)\}/
+                if (propertyPlaceholderMatch) {
+                    logLevel = "\${sys:${propertyPlaceholderMatch.group(1)}}"
+                }
+                "$loggerName" (level: logLevel) {
                     bindings['rootAppenders'].each { name ->
                         AppenderRef (ref:name.trim())
                     }


### PR DESCRIPTION
While the `-i` (`--interpolate`) flag allows for updating properties on the fly (see https://github.com/knoguchi/log4j2-migrator/commit/2f76f1c90c122023d391f82019189676ce0fca5e), this PR allows for keeping the properties and setting them as default values, while the placeholders are updated to use the `sys` lookup (since placeholders in log4j1 read from system properties by default).

See the following for detail:
* https://dougbreaux.github.io/2013/06/05/log4j-log-level.html
* https://logging.apache.org/log4j/2.x/manual/configuration.html#Properties
