### PR TITLE
XML doctype

### DIFF
--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -137,6 +137,7 @@ def generate(bindings) {
     xmlMarkup.setOmitNullAttributes(true)
     xmlMarkup.setDoubleQuotes(true)
     xmlMarkup.mkp.xmlDeclaration(version: '1.0', encoding: 'utf-8')
+    xmlMarkup.mkp.yieldUnescaped('<!DOCTYPE Configuration>' + System.getProperty("line.separator"))
     xmlMarkup
         .'Configuration' {
             if (bindings['systemProperties']) {


### PR DESCRIPTION
This PR adds a doctype to the generated XML file to avoid issues in IDEs (e.g. eclipse).